### PR TITLE
AC-503 add U.S. territories to autocomplete

### DIFF
--- a/src/components/general/inputs/google-maps-autocomplete.js
+++ b/src/components/general/inputs/google-maps-autocomplete.js
@@ -95,7 +95,8 @@ export default function GoogleMapsAutocomplete(props) {
             ...request,
             // only send back location results that are in US
             componentRestrictions: {
-              country: 'us',
+              // allows up to 5 ISO-3166 codes. 
+              country: ['as','gu','pr','us','vi'],
             },
           },
           callback,


### PR DESCRIPTION
Added Guam, Puerto Rico, American Samoa and US Virgin Isles .   
The original ticket asked for all territories but the google API can only restrict up to 5.   Not an issue because the rest of the territories are largely unpopulated 