### PR TITLE
AC-617 fix: distributed icons evenly focusing on icon instead of text

### DIFF
--- a/src/styles/_testing-location-list-item.scss
+++ b/src/styles/_testing-location-list-item.scss
@@ -223,8 +223,8 @@
 }
 
 .link-button {
-  text-align: center;  
-  width:25%;
+  text-align: center;
+  width: 25%;
 }
 
 .link-button-icon {
@@ -232,7 +232,7 @@
   border-radius: 50%;
   padding: 5px;
   font-size: 30px !important;
-  margin-bottom: 3px; 
+  margin-bottom: 3px;
 }
 
 .icons-container {
@@ -244,14 +244,14 @@
   /* border: 1px solid red; */
   /* margin: 0 auto; */
   width: 90%;
-  margin-left: 10px; 
+  margin-left: 10px;
 
   .list-item-buttons {
-    display: flex;  
+    display: flex;
     justify-content: space-evenly;
     width: 80%;
     padding-top: 18px;
-    margin: -8px 0px; 
+    margin: -8px 0px;
   }
 
   a:hover {

--- a/src/styles/_testing-location-list-item.scss
+++ b/src/styles/_testing-location-list-item.scss
@@ -223,7 +223,8 @@
 }
 
 .link-button {
-  text-align: center;
+  text-align: center;  
+  width:25%;
 }
 
 .link-button-icon {
@@ -231,7 +232,7 @@
   border-radius: 50%;
   padding: 5px;
   font-size: 30px !important;
-  margin-bottom: 3px;
+  margin-bottom: 3px; 
 }
 
 .icons-container {
@@ -243,14 +244,14 @@
   /* border: 1px solid red; */
   /* margin: 0 auto; */
   width: 90%;
-  margin-left: 10px;
+  margin-left: 10px; 
 
   .list-item-buttons {
-    display: flex;
-    justify-content: space-between;
+    display: flex;  
+    justify-content: space-evenly;
     width: 80%;
     padding-top: 18px;
-    margin: -8px 0px;
+    margin: -8px 0px; 
   }
 
   a:hover {


### PR DESCRIPTION
### Checklist for Pull Requests

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure your branch matches the naming conventions. (Something like: `AC-152`). Don't request your master!
- [ ] Your branch should only contain changes relevant to the ticket it is named after.
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start _your branch_ off _our dev_.
- [ ] Check your code additions will fail neither code linting checks nor e2e test (this will be tested automatically when you open your PR).

### Description

The Icons are now spaced out evenly horizontally. The spacing is no longer based on the text under each icon so everything remains even.  

Desktop view: 
![desktopIconView](https://user-images.githubusercontent.com/35080223/85781457-b3519d80-b6f3-11ea-9019-d79045ec8497.PNG) 

Iphone view: 
![iphoneIconView](https://user-images.githubusercontent.com/35080223/85781538-cd8b7b80-b6f3-11ea-9f77-c57da579b29e.PNG)


