### PR TITLE
AC-487 fix: test center card only displays top most chosen experience…

### DIFF
--- a/src/components/map-components/testing-location-list-item.js
+++ b/src/components/map-components/testing-location-list-item.js
@@ -16,7 +16,7 @@ import PeopleIcon from '@material-ui/icons/People';
 import LocalMallIcon from '@material-ui/icons/LocalMall';
 import EventIcon from '@material-ui/icons/Event'; 
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord';
-import {boolToEng, isNullOrUndefined, getFeedbackButtonURL, isTaggableLocation} from '@util/general.helpers';
+import {boolToEng, isNullOrUndefined, getFeedbackButtonURL, isTaggableLocation, sortExperiencesTags} from '@util/general.helpers';
 import ExternalItemLinks from './external-item-links';
 import CustomizedExpansionPanel, {ExpansionPanelSummary, ExpansionPanelDetails} from './expansion-panel';
 import {Link} from 'react-router-dom'; 
@@ -158,6 +158,10 @@ export default function TestingLocationListItem(props) {
   function buildExperienceSection(experiencesData) {
 
     const {positives, negatives, total, tags} = experiencesData;
+    const tagsArr = [];
+    map(tags, (e, i) => {
+      tagsArr.push(e);
+    });
     // const {positives, negatives, neutrals = 0, total, tags} = experiencesData; 
     const percentPostive = Math.round(positives / total * 100);
     const percentNegative = Math.round(negatives / total * 100);
@@ -203,7 +207,7 @@ export default function TestingLocationListItem(props) {
           className='experiences__tags'
         >
           {
-            map(tags, (e, i) => {
+            map(tagsArr.sort((tagA, tagB) => sortExperiencesTags(tagA,tagB)).slice(0,3), (e, i) => {
               const {count, name} = e;
               if (count) {
                 return (<Pill

--- a/src/util/general.helpers.js
+++ b/src/util/general.helpers.js
@@ -178,3 +178,11 @@ export function applyCovidTag({name, city, state, address, lastUpdated, text, ur
   loadDynamicScript('application/ld+json', JSON.stringify(tag));
   console.log('Covid tag applied');
 }
+
+export function sortExperiencesTags(tagA, tagB){
+  if((tagA.count === tagB.count) && tagA.hasOwnProperty('last')){ 
+    return Date.parse(tagB.last) - Date.parse(tagA.last);
+  } else {
+    return tagB.count - tagA.count;
+  }
+}


### PR DESCRIPTION
… attributes

### Checklist for Pull Requests

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure your branch matches the naming conventions. (Something like: `AC-152`). Don't request your master!
- [ ] Your branch should only contain changes relevant to the ticket it is named after.
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start _your branch_ off _our dev_.
- [ ] Check your code additions will fail neither code linting checks nor e2e test (this will be tested automatically when you open your PR).

### Description

- Test Center cards only display the top 3 most chosen experience attributes 
- Attributes are in descending order of most selected 
- Preference on tying attributes is given to the attribute that was most recently selected 
- Link to ticket: https://trello.com/c/rTchR8xZ/84-experiences-section-of-test-center-card-should-only-display-top-3-most-chosen-experience-attributes-ac-487 
