### PR TITLE
AC-488 bug fix: fixed next button safari bug and padding issues on ex…

### DIFF
--- a/src/components/experiences/feedback-experiences.js
+++ b/src/components/experiences/feedback-experiences.js
@@ -66,7 +66,7 @@ export default function FeedbackExperiences(props) {
         What made your testing experience {props.payload.positive ? 'positive' : 'negative'}?
     </Content>   
     
-     <Actions>    
+     <Actions disableSpacing>    
       { 
         renderTags()   
       }
@@ -99,11 +99,13 @@ const Content = styled(DialogContent)`
 const Actions = styled(DialogActions)`
   flex-direction: column; 
   align-self: center; 
+  .MuiDialogActions-root{
+    padding: 2px; 
+  }
 `;  
 const Box = styled(DialogActions)`
   flex-direction: row; 
   align-self: center;  
-  margin: 5px;
 `; 
 
 const TagButton = styled(PrimaryButton)` 
@@ -121,14 +123,14 @@ const TagButton = styled(PrimaryButton)`
 `;  
 
 const NextButton = styled(PrimaryButton)`
-  box-shadow: 0px 0px 10px 5px lightGrey; 
-  margin-top: 15px;  
+  box-shadow: 0px 0px 10px 5px lightGrey;
   align-self: center;
   width: 30%;
+  flex-direction: column;
 `; 
 
 const SpaceButton = styled(PrimaryButton)`
-  margin-top: 35px;  
+  margin-top: 15px;  
   align-self: center;
   width: 30%;
 `;

--- a/src/components/experiences/initial-experiences.js
+++ b/src/components/experiences/initial-experiences.js
@@ -88,6 +88,7 @@ const NextButton = styled(PrimaryButton)`
   align-self: center;
   width: 30%;
   box-shadow: 0px 0px 15px 5px lightGrey;
+  flex-direction: column;
 `;
 
 const SpaceButton = styled(PrimaryButton)`


### PR DESCRIPTION
Fixed next button safari bug and padding issues on experiences

### Checklist for Pull Requests

🚨Please review the [guidelines for contributing](./CONTRIBUTING.md) to this repository.

- [ ] Make sure your branch matches the naming conventions. (Something like: `AC-152`). Don't request your master!
- [ ] Your branch should only contain changes relevant to the ticket it is named after.
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start _your branch_ off _our dev_.
- [ ] Check your code additions will fail neither code linting checks nor e2e test (this will be tested automatically when you open your PR).

### Description

- fixed safari bug which cut off the "Next" text by making flex-direction column
- fixed padding issue and button spacing by disabling the default actions spacing
